### PR TITLE
Multiple fixes (response length, checkbypass logic, grammar, sorting, stripping)

### DIFF
--- a/Autorize.py
+++ b/Autorize.py
@@ -134,7 +134,7 @@ class BurpExtender(IBurpExtender, ITab, IHttpListener, IMessageEditorController,
         EDLabelList = JLabel("Filter List:")
         EDLabelList.setBounds(10, 165, 140, 30)
 
-        EDStrings = ["Headers (simple string): (enforced message headers contains)", "Headers (regex): (enforced message headers contains)", "Body (simple string): (enforced message body contains)", "Body (regex): (enforced message body contains)", "Full request (simple string): (enforced message contains)", "Full request (regex): (enforced message contains)", "Content-Length: (constant Content-Length number of enforced response)"]
+        EDStrings = ["Headers (simple string): (enforced message headers contains)", "Headers (regex): (enforced message headers contains)", "Body (simple string): (enforced message body contains)", "Body (regex): (enforced message body contains)", "Full response (simple string): (enforced message contains)", "Full response (regex): (enforced message contains)", "Content-Length: (constant Content-Length number of enforced response)"]
         self.EDType = JComboBox(EDStrings)
         self.EDType.setBounds(80, 10, 430, 30)
        
@@ -177,7 +177,7 @@ class BurpExtender(IBurpExtender, ITab, IHttpListener, IMessageEditorController,
         EDLabelList = JLabel("Filter List:")
         EDLabelList.setBounds(10, 165, 140, 30)
 
-        EDStrings = ["Headers (simple string): (enforced message headers contains)", "Headers (regex): (enforced message headers contains)", "Body (simple string): (enforced message body contains)", "Body (regex): (enforced message body contains)", "Full request (simple string): (enforced message contains)", "Full request (regex): (enforced message contains)", "Content-Length: (constant Content-Length number of enforced response)"]
+        EDStrings = ["Headers (simple string): (enforced message headers contains)", "Headers (regex): (enforced message headers contains)", "Body (simple string): (enforced message body contains)", "Body (regex): (enforced message body contains)", "Full response (simple string): (enforced message contains)", "Full response (regex): (enforced message contains)", "Content-Length: (constant Content-Length number of enforced response)"]
         self.EDTypeUnauth = JComboBox(EDStrings)
         self.EDTypeUnauth.setBounds(80, 10, 430, 30)
        
@@ -776,12 +776,12 @@ class BurpExtender(IBurpExtender, ITab, IHttpListener, IMessageEditorController,
                         if p.search(self._helpers.bytesToString(requestResponse.getResponse()[analyzedResponse.getBodyOffset():])):
                             auth_enforced = 1
 
-                    if auth_enforced == 0 and str(filter).startswith("Full request (simple string): "):
-                        if filter[30:] in self._helpers.bytesToString(requestResponse.getResponse()):
+                    if auth_enforced == 0 and str(filter).startswith("Full response (simple string): "):
+                        if filter[31:] in self._helpers.bytesToString(requestResponse.getResponse()):
                             auth_enforced = 1
 
-                    if auth_enforced == 0 and str(filter).startswith("Full request (regex): "):
-                        regex_string = filter[22:]
+                    if auth_enforced == 0 and str(filter).startswith("Full response (regex): "):
+                        regex_string = filter[23:]
                         p = re.compile(regex_string, re.IGNORECASE)
                         if p.search(self._helpers.bytesToString(requestResponse.getResponse())):
                             auth_enforced = 1

--- a/Autorize.py
+++ b/Autorize.py
@@ -876,8 +876,8 @@ class Table(JTable):
         return
 
     def prepareRenderer(self, renderer, row, col):
-        comp = JTable.prepareRenderer(self,renderer, row, col)
-        value = self._extender.getValueAt(row,col)
+        comp = JTable.prepareRenderer(self, renderer, row, col)
+        value = self._extender.getValueAt(self._extender.logTable.convertRowIndexToModel(row), col)
         
         if (value == "Authorization bypass!" and ((col == 5) or (col == 6))):
             comp.setBackground(Color(255,135,31))

--- a/Autorize.py
+++ b/Autorize.py
@@ -134,7 +134,7 @@ class BurpExtender(IBurpExtender, ITab, IHttpListener, IMessageEditorController,
         EDLabelList = JLabel("Filter List:")
         EDLabelList.setBounds(10, 165, 140, 30)
 
-        EDStrings = ["Headers (simple string): (enforced message headers contains)", "Headers (regex): (enforced messege headers contains)", "Body (simple string): (enforced messege body contains)", "Body (regex): (enforced messege body contains)", "Full request (simple string): (enforced messege contains)", "Full request (regex): (enforced messege contains)", "Content-Length: (constant Content-Length number of enforced response)"]
+        EDStrings = ["Headers (simple string): (enforced message headers contains)", "Headers (regex): (enforced message headers contains)", "Body (simple string): (enforced message body contains)", "Body (regex): (enforced message body contains)", "Full request (simple string): (enforced message contains)", "Full request (regex): (enforced message contains)", "Content-Length: (constant Content-Length number of enforced response)"]
         self.EDType = JComboBox(EDStrings)
         self.EDType.setBounds(80, 10, 430, 30)
        
@@ -177,7 +177,7 @@ class BurpExtender(IBurpExtender, ITab, IHttpListener, IMessageEditorController,
         EDLabelList = JLabel("Filter List:")
         EDLabelList.setBounds(10, 165, 140, 30)
 
-        EDStrings = ["Headers (simple string): (enforced message headers contains)", "Headers (regex): (enforced messege headers contains)", "Body (simple string): (enforced messege body contains)", "Body (regex): (enforced messege body contains)", "Full request (simple string): (enforced messege contains)", "Full request (regex): (enforced messege contains)", "Content-Length: (constant Content-Length number of enforced response)"]
+        EDStrings = ["Headers (simple string): (enforced message headers contains)", "Headers (regex): (enforced message headers contains)", "Body (simple string): (enforced message body contains)", "Body (regex): (enforced message body contains)", "Full request (simple string): (enforced message contains)", "Full request (regex): (enforced message contains)", "Content-Length: (constant Content-Length number of enforced response)"]
         self.EDTypeUnauth = JComboBox(EDStrings)
         self.EDTypeUnauth.setBounds(80, 10, 430, 30)
        

--- a/Autorize.py
+++ b/Autorize.py
@@ -134,7 +134,7 @@ class BurpExtender(IBurpExtender, ITab, IHttpListener, IMessageEditorController,
         EDLabelList = JLabel("Filter List:")
         EDLabelList.setBounds(10, 165, 140, 30)
 
-        EDStrings = ["Headers (simple string): (enforced message headers contains)", "Headers (regex): (enforced message headers contains)", "Body (simple string): (enforced message body contains)", "Body (regex): (enforced message body contains)", "Full response (simple string): (enforced message contains)", "Full response (regex): (enforced message contains)", "Content-Length: (constant Content-Length number of enforced response)"]
+        EDStrings = ["Headers (simple string): (enforced message headers contains)", "Headers (regex): (enforced message headers contains)", "Body (simple string): (enforced message body contains)", "Body (regex): (enforced message body contains)", "Full response (simple string): (enforced message contains)", "Full response (regex): (enforced message contains)", "Full response length: (of enforced response)"]
         self.EDType = JComboBox(EDStrings)
         self.EDType.setBounds(80, 10, 430, 30)
        
@@ -177,7 +177,7 @@ class BurpExtender(IBurpExtender, ITab, IHttpListener, IMessageEditorController,
         EDLabelList = JLabel("Filter List:")
         EDLabelList.setBounds(10, 165, 140, 30)
 
-        EDStrings = ["Headers (simple string): (enforced message headers contains)", "Headers (regex): (enforced message headers contains)", "Body (simple string): (enforced message body contains)", "Body (regex): (enforced message body contains)", "Full response (simple string): (enforced message contains)", "Full response (regex): (enforced message contains)", "Content-Length: (constant Content-Length number of enforced response)"]
+        EDStrings = ["Headers (simple string): (enforced message headers contains)", "Headers (regex): (enforced message headers contains)", "Body (simple string): (enforced message body contains)", "Body (regex): (enforced message body contains)", "Full response (simple string): (enforced message contains)", "Full response (regex): (enforced message contains)", "Full response length: (of enforced response)"]
         self.EDTypeUnauth = JComboBox(EDStrings)
         self.EDTypeUnauth.setBounds(80, 10, 430, 30)
        
@@ -742,7 +742,8 @@ class BurpExtender(IBurpExtender, ITab, IHttpListener, IMessageEditorController,
 
     def checkBypass(self,oldStatusCode,newStatusCode,oldContentLen,newContentLen,filters,requestResponse):
 
-        analyzedResponse = self._helpers.analyzeResponse(requestResponse.getResponse())
+        response = requestResponse.getResponse()
+        analyzedResponse = self._helpers.analyzeResponse(response)
         impression = ""
 
         if oldStatusCode == newStatusCode:
@@ -786,8 +787,8 @@ class BurpExtender(IBurpExtender, ITab, IHttpListener, IMessageEditorController,
                         if p.search(self._helpers.bytesToString(requestResponse.getResponse())):
                             auth_enforced = 1
 
-                    if auth_enforced == 0 and str(filter).startswith("Content-Length: "):
-                        if str(newContentLen) == filter[16:].strip():
+                    if auth_enforced == 0 and str(filter).startswith("Full response length: "):
+                        if str(len(response)) == filter[22:].strip():
                             auth_enforced = 1
                 
                 if auth_enforced:

--- a/Autorize.py
+++ b/Autorize.py
@@ -398,7 +398,7 @@ class BurpExtender(IBurpExtender, ITab, IHttpListener, IMessageEditorController,
 
     def addEDFilter(self, event):
         typeName = self.EDType.getSelectedItem().split(":")[0]
-        self.EDModel.addElement(typeName + ": " + self.EDText.getText())
+        self.EDModel.addElement(typeName + ": " + self.EDText.getText().strip())
 
     def delEDFilter(self, event):
         index = self.EDList.getSelectedIndex();
@@ -407,7 +407,7 @@ class BurpExtender(IBurpExtender, ITab, IHttpListener, IMessageEditorController,
 
     def addEDFilterUnauth(self, event):
         typeName = self.EDTypeUnauth.getSelectedItem().split(":")[0]
-        self.EDModelUnauth.addElement(typeName + ": " + self.EDTextUnauth.getText())
+        self.EDModelUnauth.addElement(typeName + ": " + self.EDTextUnauth.getText().strip())
 
     def delEDFilterUnauth(self, event):
         index = self.EDListUnauth.getSelectedIndex();
@@ -416,7 +416,7 @@ class BurpExtender(IBurpExtender, ITab, IHttpListener, IMessageEditorController,
 
     def addIFFilter(self, event):
         typeName = self.IFType.getSelectedItem().split(":")[0]
-        self.IFModel.addElement(typeName + ": " + self.IFText.getText())
+        self.IFModel.addElement(typeName + ": " + self.IFText.getText().strip())
 
     def delIFFilter(self, event):
         index = self.IFList.getSelectedIndex();

--- a/Autorize.py
+++ b/Autorize.py
@@ -787,12 +787,7 @@ class BurpExtender(IBurpExtender, ITab, IHttpListener, IMessageEditorController,
                             auth_enforced = 1
 
                     if auth_enforced == 0 and str(filter).startswith("Content-Length: "):
-                        filterLen = None
-                        try:
-                            filterLen = int(filter[16:])
-                        except ValueError:
-                            pass
-                        if filterLen != None and newContentLen == filterLen:
+                        if str(newContentLen) == filter[16:].strip():
                             auth_enforced = 1
                 
                 if auth_enforced:


### PR DESCRIPTION
What has been fixed:

- checkBypass will now compare actual response length instead of Content-Length header (which might not be present in all responses, but can be computed using full response)

- checkBypass logic is now inverted. It is enough for one rule to match in order to yield auth_enforced = 1

- Typo fixed ("messege" => "message") 

- Authorization enforcement status cell backgrounds will now follow sorting order (if you sorted in reverse order by id, colors didn't follow actual content, now it is fixed)

- "Full request" has been changed to "Full response" (it actually is a response)

- Content-Length header value comparison check has been simplified (now it is again string comparison)

- "Content-Length" filter has been renamed to "Full response length", check has been fixed (earlier it could cause some confusion, as Autorize columns show full response length, while filter referred and checked Content-Length header, which, again, might be missing)

- Filter input is now stripped of whitespaces and newlines (due to that, i.e. regex filters for urls now behave correctly if someone pastes it with newline and the end)
