### PR TITLE
removeHeaders updated to remove inserted headers

### DIFF
--- a/Autorize.py
+++ b/Autorize.py
@@ -409,7 +409,7 @@ class BurpExtender(IBurpExtender, ITab, IHttpListener, IMessageEditorController,
         self.clearButton = JButton("Clear List",actionPerformed=self.clearList)
         self.clearButton.setBounds(10, 40, 100, 30)
 
-        self.replaceString = JTextArea("Cookie: Insert=injected; header=here;", 5, 30)
+        self.replaceString = JTextArea("Cookie: Insert=injected\nHeader: here", 5, 30)
         self.replaceString.setWrapStyleWord(True)
         self.replaceString.setLineWrap(True)
         scrollReplaceString = JScrollPane(self.replaceString)
@@ -1025,8 +1025,9 @@ class BurpExtender(IBurpExtender, ITab, IHttpListener, IMessageEditorController,
         headers = requestInfo.getHeaders()
         if removeOrNot:
             headers = list(headers)
-            removeHeaders = ArrayList()
-            removeHeaders.add(self.replaceString.getText()[0:self.replaceString.getText().index(":")])
+            removeHeaders = self.replaceString.getText()
+            # Headers must be entered line by line i.e. each header in a new line
+            removeHeaders = [header for header in removeHeaders.split() if header.endswith(':')]
 
             for header in headers[:]:
                 for removeHeader in removeHeaders:

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Autorize is an automatic authorization enforcement detection extension for Burp 
 1.	After installation, the Autorize tab will be added to Burp.
 2.	Open the configuration tab (Autorize -> Configuration).
 3.	Get your low-privileged user authorization token header (Cookie / Authorization) and copy it into the textbox containing the text "Insert injected header here".
+**Note**: Headers inserted here will be replaced if present or added if not.
 4.  Uncheck "Check unauthenticated" if the authentication test is not required (request without any cookies, to check for authentication enforcement in addiction to authorization enforcement with the cookies of low-privileged user)
 5.	Click on "Intercept is off" to start intercepting the traffic in order to allow Autorize to check for authorization enforcement.
 6.	Open a browser and configure the proxy settings so the traffic will be passed to Burp.


### PR DESCRIPTION
This should replace headers inserted in the text field.  
Headers must be entered line by line, as in real HTTP Request. Separating headers with space or comma creates problem. And **:** that doesn't define headers must be percent encoded.

 