### PR TITLE
fix missing carriage return on *NIX systems

### DIFF
--- a/Autorize.py
+++ b/Autorize.py
@@ -1081,7 +1081,7 @@ class BurpExtender(IBurpExtender, ITab, IHttpListener, IMessageEditorController,
             if authorizeOrNot:
                 # fix missing carriage return on *NIX systems
                 replaceStringLines = self.replaceString.getText().split("\n")
-                print(replaceStringLines)
+                
                 for h in replaceStringLines:
                     headers.append(h)
 

--- a/Autorize.py
+++ b/Autorize.py
@@ -1079,7 +1079,11 @@ class BurpExtender(IBurpExtender, ITab, IHttpListener, IMessageEditorController,
                         headers.remove(header)
 
             if authorizeOrNot:
-                headers.append(self.replaceString.getText())
+                # fix missing carriage return on *NIX systems
+                replaceStringLines = self.replaceString.getText().split("\n")
+                print(replaceStringLines)
+                for h in replaceStringLines:
+                    headers.append(h)
 
         msgBody = messageInfo.getRequest()[requestInfo.getBodyOffset():]
         return self._helpers.buildHttpMessage(headers, msgBody)


### PR DESCRIPTION
Headers where to added to header list line by line, but whole replace string was added into the one header field