### PR TITLE
Prevent False Positive When Both Content-Length and Status-Code match

### DIFF
--- a/Autorize.py
+++ b/Autorize.py
@@ -1142,89 +1142,88 @@ class BurpExtender(IBurpExtender, ITab, IHttpListener, IMessageEditorController,
         if oldStatusCode == newStatusCode:
             if oldContentLen == newContentLen:
                 impression = self._enfocementStatuses[0]
-            else:
+            
+            if len(filters) > 0:
 
-                if len(filters) > 0:
-
-                    if andOrEnforcement == "And":
-                        andEnforcementCheck = True
-                        auth_enforced = 1
-                    else:
-                        andEnforcementCheck = False
-                        auth_enforced = 0
-                    
-                    for filter in filters:
-
-                        if str(filter).startswith("Headers (simple string): "):
-                            if andEnforcementCheck:
-                                if auth_enforced == 1 and not filter[25:] in self._helpers.bytesToString(requestResponse.getResponse()[0:analyzedResponse.getBodyOffset()]):
-                                    auth_enforced = 0
-                            else:
-                                if auth_enforced == 0 and filter[25:] in self._helpers.bytesToString(requestResponse.getResponse()[0:analyzedResponse.getBodyOffset()]):
-                                    auth_enforced = 1
-
-                        if str(filter).startswith("Headers (regex): "):
-                            regex_string = filter[17:]
-                            p = re.compile(regex_string, re.IGNORECASE)                        
-                            if andEnforcementCheck:
-                                if auth_enforced == 1 and not p.search(self._helpers.bytesToString(requestResponse.getResponse()[0:analyzedResponse.getBodyOffset()])):
-                                    auth_enforced = 0
-                            else:
-                                if auth_enforced == 0 and p.search(self._helpers.bytesToString(requestResponse.getResponse()[0:analyzedResponse.getBodyOffset()])):
-                                    auth_enforced = 1
-
-                        if str(filter).startswith("Body (simple string): "):
-                            if andEnforcementCheck:
-                                if auth_enforced == 1 and not filter[22:] in self._helpers.bytesToString(requestResponse.getResponse()[analyzedResponse.getBodyOffset():]):
-                                    auth_enforced = 0
-                            else:
-                                if auth_enforced == 0 and filter[22:] in self._helpers.bytesToString(requestResponse.getResponse()[analyzedResponse.getBodyOffset():]):
-                                    auth_enforced = 1
-
-                        if str(filter).startswith("Body (regex): "):
-                            regex_string = filter[14:]
-                            p = re.compile(regex_string, re.IGNORECASE)
-                            if andEnforcementCheck:
-                                if auth_enforced == 1 and not p.search(self._helpers.bytesToString(requestResponse.getResponse()[analyzedResponse.getBodyOffset():])):
-                                    auth_enforced = 0
-                            else:
-                                if auth_enforced == 0 and p.search(self._helpers.bytesToString(requestResponse.getResponse()[analyzedResponse.getBodyOffset():])):
-                                    auth_enforced = 1
-
-                        if str(filter).startswith("Full response (simple string): "):
-                            if andEnforcementCheck:
-                                if auth_enforced == 1 and not filter[31:] in self._helpers.bytesToString(requestResponse.getResponse()):
-                                    auth_enforced = 0
-                            else:
-                                if auth_enforced == 0 and filter[31:] in self._helpers.bytesToString(requestResponse.getResponse()):
-                                    auth_enforced = 1
-
-                        if str(filter).startswith("Full response (regex): "):
-                            regex_string = filter[23:]
-                            p = re.compile(regex_string, re.IGNORECASE)
-                            if andEnforcementCheck:
-                                if auth_enforced == 1 and not p.search(self._helpers.bytesToString(requestResponse.getResponse())):
-                                    auth_enforced = 0
-                            else:
-                                if auth_enforced == 0 and p.search(self._helpers.bytesToString(requestResponse.getResponse())):
-                                    auth_enforced = 1
-
-                        if str(filter).startswith("Full response length: "):
-                            if andEnforcementCheck:
-                                if auth_enforced == 1 and not str(len(response)) == filter[22:].strip():
-                                    auth_enforced = 0
-                            else:
-                                if auth_enforced == 0 and str(len(response)) == filter[22:].strip():
-                                    auth_enforced = 1
-                
+                if andOrEnforcement == "And":
+                    andEnforcementCheck = True
+                    auth_enforced = 1
                 else:
-                    # If no enforcement detectors are set and the HTTP response is the same, the impression is yellow
+                    andEnforcementCheck = False
                     auth_enforced = 0
-                
-                if auth_enforced:
-                    impression = self._enfocementStatuses[2]
-                else:
-                    impression = self._enfocementStatuses[1]
+
+                for filter in filters:
+
+                    if str(filter).startswith("Headers (simple string): "):
+                        if andEnforcementCheck:
+                            if auth_enforced == 1 and not filter[25:] in self._helpers.bytesToString(requestResponse.getResponse()[0:analyzedResponse.getBodyOffset()]):
+                                auth_enforced = 0
+                        else:
+                            if auth_enforced == 0 and filter[25:] in self._helpers.bytesToString(requestResponse.getResponse()[0:analyzedResponse.getBodyOffset()]):
+                                auth_enforced = 1
+
+                    if str(filter).startswith("Headers (regex): "):
+                        regex_string = filter[17:]
+                        p = re.compile(regex_string, re.IGNORECASE)                        
+                        if andEnforcementCheck:
+                            if auth_enforced == 1 and not p.search(self._helpers.bytesToString(requestResponse.getResponse()[0:analyzedResponse.getBodyOffset()])):
+                                auth_enforced = 0
+                        else:
+                            if auth_enforced == 0 and p.search(self._helpers.bytesToString(requestResponse.getResponse()[0:analyzedResponse.getBodyOffset()])):
+                                auth_enforced = 1
+
+                    if str(filter).startswith("Body (simple string): "):
+                        if andEnforcementCheck:
+                            if auth_enforced == 1 and not filter[22:] in self._helpers.bytesToString(requestResponse.getResponse()[analyzedResponse.getBodyOffset():]):
+                                auth_enforced = 0
+                        else:
+                            if auth_enforced == 0 and filter[22:] in self._helpers.bytesToString(requestResponse.getResponse()[analyzedResponse.getBodyOffset():]):
+                                auth_enforced = 1
+
+                    if str(filter).startswith("Body (regex): "):
+                        regex_string = filter[14:]
+                        p = re.compile(regex_string, re.IGNORECASE)
+                        if andEnforcementCheck:
+                            if auth_enforced == 1 and not p.search(self._helpers.bytesToString(requestResponse.getResponse()[analyzedResponse.getBodyOffset():])):
+                                auth_enforced = 0
+                        else:
+                            if auth_enforced == 0 and p.search(self._helpers.bytesToString(requestResponse.getResponse()[analyzedResponse.getBodyOffset():])):
+                                auth_enforced = 1
+
+                    if str(filter).startswith("Full response (simple string): "):
+                        if andEnforcementCheck:
+                            if auth_enforced == 1 and not filter[31:] in self._helpers.bytesToString(requestResponse.getResponse()):
+                                auth_enforced = 0
+                        else:
+                            if auth_enforced == 0 and filter[31:] in self._helpers.bytesToString(requestResponse.getResponse()):
+                                auth_enforced = 1
+
+                    if str(filter).startswith("Full response (regex): "):
+                        regex_string = filter[23:]
+                        p = re.compile(regex_string, re.IGNORECASE)
+                        if andEnforcementCheck:
+                            if auth_enforced == 1 and not p.search(self._helpers.bytesToString(requestResponse.getResponse())):
+                                auth_enforced = 0
+                        else:
+                            if auth_enforced == 0 and p.search(self._helpers.bytesToString(requestResponse.getResponse())):
+                                auth_enforced = 1
+
+                    if str(filter).startswith("Full response length: "):
+                        if andEnforcementCheck:
+                            if auth_enforced == 1 and not str(len(response)) == filter[22:].strip():
+                                auth_enforced = 0
+                        else:
+                            if auth_enforced == 0 and str(len(response)) == filter[22:].strip():
+                                auth_enforced = 1
+
+            else:
+                # If no enforcement detectors are set and the HTTP response is the same, the impression is yellow
+                auth_enforced = 0
+
+            if auth_enforced:
+                impression = self._enfocementStatuses[2]
+            else:
+                impression = self._enfocementStatuses[1]
                          
         else:
             impression = self._enfocementStatuses[2]


### PR DESCRIPTION
Hi there.

Thanks for your plugin, it's pretty great. I have found an edge case that I fixed with the code change I am proposing. 

The situation occurs when both the enforced response and non-enforced response share a status code and a content length, but they are nontheless different. This happens frequently with the `post-then-redirect` pattern. For example:

```
Enforced: 301, content-length 0, Location: /admin/login.php
Non-Enforced: 301, content-length 0, Location /admin/edit.php
```

This code change allows to work this location into a filter, and (I hope) doesn't break anything else.

