### PR TITLE
Added "Send to Repeater" context menu option

### DIFF
--- a/Autorize.py
+++ b/Autorize.py
@@ -532,6 +532,12 @@ class BurpExtender(IBurpExtender, ITab, IHttpListener, IMessageEditorController,
 
         copyURLitem = JMenuItem("Copy URL")
         copyURLitem.addActionListener(copySelectedURL(self))
+
+        ## PR
+        sendRequestMenu = JMenuItem("Send to Repeater")
+        sendRequestMenu.addActionListener(sendRequestRepeater(self, self._callbacks))
+
+
         retestSelecteditem = JMenuItem("Retest selected request")
         retestSelecteditem.addActionListener(retestSelectedRequest(self))
         deleteSelectedItem = JMenuItem("Delete")
@@ -539,6 +545,7 @@ class BurpExtender(IBurpExtender, ITab, IHttpListener, IMessageEditorController,
 
 
         self.menu = JPopupMenu("Popup")
+        self.menu.add(sendRequestMenu)
         self.menu.add(copyURLitem)
         self.menu.add(retestSelecteditem)
         # self.menu.add(deleteSelectedItem) disabling this feature until bug will be fixed.
@@ -1375,6 +1382,19 @@ class autoScrollListener(AdjustmentListener):
     def adjustmentValueChanged(self, e):
         if self._extender.autoScroll.isSelected() is True:
             e.getAdjustable().setValue(e.getAdjustable().getMaximum())
+
+class sendRequestRepeater(ActionListener):
+    def __init__(self, extender, callbacks):
+        self._extender = extender
+        self._callbacks = callbacks
+
+    def actionPerformed(self, e):
+        request = self._extender._currentlyDisplayedItem._requestResponse
+        host = request.getHttpService().getHost()
+        port = request.getHttpService().getPort()
+        
+        self._callbacks.sendToRepeater(host, port, 1, request.getRequest(), "Autorize");
+
 
 class copySelectedURL(ActionListener):
     def __init__(self, extender):


### PR DESCRIPTION
Select a request in the table, right click -> "Send to Repeater"
<img width="736" alt="pr" src="https://user-images.githubusercontent.com/1380527/48310438-443d3900-e5e3-11e8-9e61-9f35ec6a3302.png">

Nice to have: wasn't able to set the last argument of sendToRepeater to null as specified in the documentation, so I've hardcoded a string for now.