### PR TITLE
Bug fix#82

### DIFF
--- a/authorization/authorization.py
+++ b/authorization/authorization.py
@@ -355,7 +355,7 @@ def checkAuthorization(self, messageInfo, originalHeaders, checkUnauthorized):
 def checkAuthorizationV2(self, messageInfo):
     checkAuthorization(self, messageInfo, self._extender._helpers.analyzeResponse(messageInfo.getResponse()).getHeaders(), self._extender.doUnauthorizedRequest.isSelected())
 
-test = test
+test = "test"
 def retestAllRequests(self):
     for i in range(self.tableModel.getRowCount()):
         logEntry = self._log.get(self.logTable.convertRowIndexToModel(i))

--- a/authorization/authorization.py
+++ b/authorization/authorization.py
@@ -357,6 +357,6 @@ def checkAuthorizationV2(self, messageInfo):
 
 def retestAllRequests(self):
     for i in range(self.tableModel.getRowCount()):
-        self.logTable.setAutoCreateRowSorter(True)
+        self.logTable.setAutoCreateRowSorter(True )
         logEntry = self._log.get(self.logTable.convertRowIndexToModel(i))
         handle_message(self, "AUTORIZE", False, logEntry._originalrequestResponse)

--- a/authorization/authorization.py
+++ b/authorization/authorization.py
@@ -355,6 +355,7 @@ def checkAuthorization(self, messageInfo, originalHeaders, checkUnauthorized):
 def checkAuthorizationV2(self, messageInfo):
     checkAuthorization(self, messageInfo, self._extender._helpers.analyzeResponse(messageInfo.getResponse()).getHeaders(), self._extender.doUnauthorizedRequest.isSelected())
 
+test = test
 def retestAllRequests(self):
     for i in range(self.tableModel.getRowCount()):
         logEntry = self._log.get(self.logTable.convertRowIndexToModel(i))

--- a/authorization/authorization.py
+++ b/authorization/authorization.py
@@ -357,5 +357,6 @@ def checkAuthorizationV2(self, messageInfo):
 
 def retestAllRequests(self):
     for i in range(self.tableModel.getRowCount()):
+        self.logTable.setAutoCreateRowSorter(True)
         logEntry = self._log.get(self.logTable.convertRowIndexToModel(i))
         handle_message(self, "AUTORIZE", False, logEntry._originalrequestResponse)

--- a/authorization/authorization.py
+++ b/authorization/authorization.py
@@ -355,7 +355,6 @@ def checkAuthorization(self, messageInfo, originalHeaders, checkUnauthorized):
 def checkAuthorizationV2(self, messageInfo):
     checkAuthorization(self, messageInfo, self._extender._helpers.analyzeResponse(messageInfo.getResponse()).getHeaders(), self._extender.doUnauthorizedRequest.isSelected())
 
-test = "test"
 def retestAllRequests(self):
     for i in range(self.tableModel.getRowCount()):
         logEntry = self._log.get(self.logTable.convertRowIndexToModel(i))

--- a/authorization/authorization.py
+++ b/authorization/authorization.py
@@ -357,6 +357,6 @@ def checkAuthorizationV2(self, messageInfo):
 
 def retestAllRequests(self):
     for i in range(self.tableModel.getRowCount()):
-        self.logTable.setAutoCreateRowSorter(True )
+        self.logTable.setAutoCreateRowSorter(True)
         logEntry = self._log.get(self.logTable.convertRowIndexToModel(i))
         handle_message(self, "AUTORIZE", False, logEntry._originalrequestResponse)


### PR DESCRIPTION
Adding a line under retestAllRequests() that resorts the table prior to repeating all the requests. This prevents the duplicate requests as it forces new request to print at the bottom of the table.