### PR TITLE
Include configuration in save/restore functionality

### DIFF
--- a/gui/export.py
+++ b/gui/export.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*- 
+# -*- coding: utf-8 -*-
 
 import sys
 sys.path.append("..")
@@ -41,7 +41,7 @@ class Export():
     def draw(self):
             """ init Save/Restore
             """
-            
+
             exportLabel = JLabel("Export:")
             exportLabel.setBounds(10, 10, 100, 30)
             labelFont = exportLabel.getFont()
@@ -74,7 +74,7 @@ class Export():
                                         actionPerformed=self.export)
             self.exportButton.setBounds(390, 50, 100, 30)
 
-            saveRestoreLabel = JLabel("State:")
+            saveRestoreLabel = JLabel("State (incl. Configuration):")
             saveRestoreLabel.setBounds(10, 160, 250, 30)
             saveRestoreLabel.setFont(boldFont)
 
@@ -84,10 +84,10 @@ class Export():
 
             self.restoreStateButton = JButton("Restore",
                                             actionPerformed=self.restoreStateAction)
-            self.restoreStateButton.setBounds(390, 200, 100, 30)        
-            
+            self.restoreStateButton.setBounds(390, 200, 100, 30)
+
             self._extender.exportPnl = JPanel()
-            exportPnl = self._extender.exportPnl 
+            exportPnl = self._extender.exportPnl
             exportPnl.setLayout(None)
             exportPnl.setBounds(0, 0, 1000, 1000)
             exportPnl.add(exportLabel)
@@ -109,7 +109,7 @@ class Export():
 
     def saveStateAction(self, event):
         self.save_restore.saveState()
-        
+
     def restoreStateAction(self, event):
         self.save_restore.restoreState()
 
@@ -220,7 +220,7 @@ class Export():
                     unique_CVS_lines.add(lineData)
             if enforcementStatusFilter == "All Statuses":
                 csvContent += "%d\t%s\t%s\t%d\t%d\t%d\t%s\t%s\n" % (self._log.get(i)._id, self._log.get(i)._method, self._log.get(i)._url, len(self._log.get(i)._originalrequestResponse.getResponse()) if self._log.get(i)._originalrequestResponse is not None else 0, len(self._log.get(i)._requestResponse.getResponse()) if self._log.get(i)._requestResponse is not None else 0, len(self._log.get(i)._unauthorizedRequestResponse.getResponse()) if self._log.get(i)._unauthorizedRequestResponse is not None else 0, self._log.get(i)._enfocementStatus, self._log.get(i)._enfocementStatusUnauthorized)
-            elif enforcementStatusFilter == "As table filter":                
+            elif enforcementStatusFilter == "As table filter":
                 if ((self._extender.showAuthBypassModified.isSelected() and self.BYPASSSED_STR == self._log.get(i)._enfocementStatus) or
                     (self._extender.showAuthPotentiallyEnforcedModified.isSelected() and "Is enforced???" == self._log.get(i)._enfocementStatus) or
                     (self._extender.showAuthEnforcedModified.isSelected() and self.ENFORCED_STR == self._log.get(i)._enfocementStatus) or
@@ -237,4 +237,3 @@ class Export():
         f = open(fileToSave.getAbsolutePath(), 'w')
         f.writelines(csvContent)
         f.close()
-

--- a/gui/save_restore.py
+++ b/gui/save_restore.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*- 
+# -*- coding: utf-8 -*-
 
 from javax.swing import SwingUtilities
 from javax.swing import JFileChooser
@@ -9,7 +9,7 @@ from java.io import File
 from table import LogEntry, UpdateTableEDT
 from helpers.http import IHttpRequestResponseImplementation
 
-import csv, base64, sys
+import csv, base64, json, re, sys
 
 # This code is necessary to maximize the csv field limit for the save and
 # restore functionality
@@ -26,17 +26,68 @@ while decrement:
 class SaveRestore():
     def __init__(self, extender):
         self._extender = extender
+        self._checkBoxes = [
+            "autoScroll",
+            "ignore304",
+            "prevent304",
+            "interceptRequestsfromRepeater",
+            "doUnauthorizedRequest",
+            "replaceQueryParam",
+            "showAuthBypassModified",
+            "showAuthPotentiallyEnforcedModified",
+            "showAuthEnforcedModified",
+            "showAuthBypassUnauthenticated",
+            "showAuthPotentiallyEnforcedUnauthenticated",
+            "showAuthEnforcedUnauthenticated",
+            "showDisabledUnauthenticated"
+        ]
 
     def saveState(self):
         parentFrame = JFrame()
         fileChooser = JFileChooser()
         fileChooser.setDialogTitle("State output file")
         userSelection = fileChooser.showSaveDialog(parentFrame)
-        
+
         if userSelection == JFileChooser.APPROVE_OPTION:
             exportFile = fileChooser.getSelectedFile()
             with open(exportFile.getAbsolutePath(), 'wb') as csvfile:
                 csvwriter = csv.writer(csvfile, delimiter='\t', quotechar='|', quoting=csv.QUOTE_MINIMAL)
+
+                # Configuration
+                tempRow = ["ReplaceString", base64.b64encode(self._extender.replaceString.getText())]
+                csvwriter.writerow(tempRow)
+
+                for EDFilter in self._extender.EDModel.toArray():
+                    tempRow = ["EDFilter", base64.b64encode(EDFilter)]
+                    csvwriter.writerow(tempRow)
+
+                for EDFilterUnauth in self._extender.EDModelUnauth.toArray():
+                    tempRow = ["EDFilterUnauth", base64.b64encode(EDFilterUnauth)]
+                    csvwriter.writerow(tempRow)
+
+                for IFFilter in self._extender.IFModel.toArray():
+                    tempRow = ["IFFilter", base64.b64encode(IFFilter)]
+                    csvwriter.writerow(tempRow)
+
+                for t in ["AndOrType", "AndOrTypeUnauth"]:
+                    tempRow = [t, getattr(self._extender, t).getSelectedItem()]
+                    csvwriter.writerow(tempRow)
+
+                for key in self._extender.badProgrammerMRModel:
+                    d = dict(self._extender.badProgrammerMRModel[key])
+                    d["regexMatch"] = d["regexMatch"] is not None
+                    tempRow = ["MatchReplace", base64.b64encode(json.dumps(d))]
+                    csvwriter.writerow(tempRow)
+
+                d = dict((c, getattr(self._extender, c).isSelected()) for c in self._checkBoxes)
+                tempRow = ["CheckBoxes", json.dumps(d)]
+                csvwriter.writerow(tempRow)
+
+                isSelected = self._extender.exportPnl.getComponents()[-1].isSelected()
+                tempRow = ["RemoveDuplicates", json.dumps(isSelected)]
+                csvwriter.writerow(tempRow)
+
+                # Request/response list
                 for i in range(0,self._extender._log.size()):
                     tempRequestResponseHost = self._extender._log.get(i)._requestResponse.getHttpService().getHost()
                     tempRequestResponsePort = self._extender._log.get(i)._requestResponse.getHttpService().getPort()
@@ -48,7 +99,7 @@ class SaveRestore():
                     tempOriginalRequestResponsePort = self._extender._log.get(i)._originalrequestResponse.getHttpService().getPort()
                     tempOriginalRequestResponseProtocol = self._extender._log.get(i)._originalrequestResponse.getHttpService().getProtocol()
                     tempOriginalRequestResponseRequest = base64.b64encode(self._extender._log.get(i)._originalrequestResponse.getRequest())
-                    tempOriginalRequestResponseResponse   = base64.b64encode(self._extender._log.get(i)._originalrequestResponse.getResponse())
+                    tempOriginalRequestResponseResponse = base64.b64encode(self._extender._log.get(i)._originalrequestResponse.getResponse())
 
                     if self._extender._log.get(i)._unauthorizedRequestResponse is not None:
                         tempUnauthorizedRequestResponseHost = self._extender._log.get(i)._unauthorizedRequestResponse.getHttpService().getHost()
@@ -64,7 +115,7 @@ class SaveRestore():
                         tempUnauthorizedRequestResponseResponse = None
 
                     tempEnforcementStatus = self._extender._log.get(i)._enfocementStatus
-                    tempEnforcementStatusUnauthorized  = self._extender._log.get(i)._enfocementStatusUnauthorized           
+                    tempEnforcementStatusUnauthorized = self._extender._log.get(i)._enfocementStatusUnauthorized
 
                     tempRow = [tempRequestResponseHost,tempRequestResponsePort,tempRequestResponseProtocol,tempRequestResponseRequest,tempRequestResponseResponse]
                     tempRow.extend([tempOriginalRequestResponseHost,tempOriginalRequestResponsePort,tempOriginalRequestResponseProtocol,tempOriginalRequestResponseRequest,tempOriginalRequestResponseResponse])
@@ -77,8 +128,13 @@ class SaveRestore():
         parentFrame = JFrame()
         fileChooser = JFileChooser()
         fileChooser.setDialogTitle("State import file")
-        userSelection = fileChooser.showDialog(parentFrame,"Restore")
-        
+        userSelection = fileChooser.showDialog(parentFrame, "Restore")
+        modelMap = {
+            "IFFilter": self._extender.IFModel,
+            "EDFilter": self._extender.EDModel,
+            "EDFilterUnauth": self._extender.EDModelUnauth
+        }
+
         if userSelection == JFileChooser.APPROVE_OPTION:
             importFile = fileChooser.getSelectedFile()
 
@@ -87,7 +143,52 @@ class SaveRestore():
                 csvreader = csv.reader(csvfile, delimiter='\t', quotechar='|')
 
                 for row in csvreader:
+                    # Configuration
+                    if row[0] == "ReplaceString":
+                        self._extender.replaceString.setText(base64.b64decode(row[1]))
+                        continue
 
+                    if row[0] in modelMap:
+                        f = base64.b64decode(row[1])
+                        if f not in modelMap[row[0]].toArray():
+                            modelMap[row[0]].addElement(f)
+                        continue
+
+                    if row[0] in {"AndOrType", "AndOrTypeUnauth"}:
+                        getattr(self._extender, row[0]).setSelectedItem(row[1])
+                        continue
+
+                    if row[0] == "MatchReplace":
+                        d = json.loads(base64.b64decode(row[1]))
+                        key = d["type"] + " " + d["match"] + "->" + d["replace"]
+                        if key in self._extender.badProgrammerMRModel:
+                            continue
+                        regexMatch = None
+                        if d["regexMatch"]:
+                            try:
+                                d["regexMatch"] = re.compile(d["match"])
+                            except re.error:
+                                print("ERROR: Regex to restore is invalid:", d["match"])
+                                continue
+                        self._extender.badProgrammerMRModel[key] = d
+                        self._extender.MRModel.addElement(key)
+                        continue
+
+                    if row[0] == "CheckBoxes":
+                        d = json.loads(row[1])
+                        for k in d:
+                            getattr(self._extender, k).setSelected(d[k])
+                        continue
+
+                    if row[0] == "RemoveDuplicates":
+                        isSelected = json.loads(row[1])
+                        try:
+                            self._extender.exportPnl.getComponents()[-1].setSelected(isSelected)
+                        except TypeError:  # suppress TypeError: None required for void return
+                            pass
+                        continue
+
+                    # Request/response list
                     tempRequestResponseHost = row[0]
                     tempRequestResponsePort = row[1]
                     tempRequestResponseProtocol = row[2]
@@ -101,11 +202,11 @@ class SaveRestore():
                     tempOriginalRequestResponsePort = row[6]
                     tempOriginalRequestResponseProtocol = row[7]
                     tempOriginalRequestResponseRequest = base64.b64decode(row[8])
-                    tempOriginalRequestResponseResponse   = base64.b64decode(row[9])
+                    tempOriginalRequestResponseResponse = base64.b64decode(row[9])
 
                     tempOriginalRequestResponseHttpService = self._extender._helpers.buildHttpService(tempOriginalRequestResponseHost,int(tempOriginalRequestResponsePort),tempOriginalRequestResponseProtocol)
                     tempOriginalRequestResponse = IHttpRequestResponseImplementation(tempOriginalRequestResponseHttpService,tempOriginalRequestResponseRequest,tempOriginalRequestResponseResponse)
-                    
+
                     checkAuthentication = True
                     if row[10] != '':
                         tempUnauthorizedRequestResponseHost = row[10]
@@ -117,13 +218,13 @@ class SaveRestore():
                         tempUnauthorizedRequestResponse = IHttpRequestResponseImplementation(tempUnauthorizedRequestResponseHttpService,tempUnauthorizedRequestResponseRequest,tempUnauthorizedRequestResponseResponse)
                     else:
                         checkAuthentication = False
-                        tempUnauthorizedRequestResponse = None                      
+                        tempUnauthorizedRequestResponse = None
 
                     tempEnforcementStatus = row[15]
-                    tempEnforcementStatusUnauthorized  = row[16]
+                    tempEnforcementStatusUnauthorized = row[16]
 
                     self._extender._lock.acquire()
-        
+
                     row = self._extender._log.size()
 
                     if checkAuthentication:
@@ -139,7 +240,7 @@ class SaveRestore():
                     else:
                         self._extender._log.add(
                             LogEntry(self._extender.currentRequestNumber,
-                            self._extender._callbacks.saveBuffersToTempFiles(tempRequestResponse), 
+                            self._extender._callbacks.saveBuffersToTempFiles(tempRequestResponse),
                             self._extender._helpers.analyzeRequest(tempRequestResponse).getMethod(),
                              self._extender._helpers.analyzeRequest(tempRequestResponse).getUrl(),
                               self._extender._callbacks.saveBuffersToTempFiles(tempOriginalRequestResponse),
@@ -159,4 +260,3 @@ class SaveRestore():
                     if authorizationHeader:
                         self._extender.lastAuthorizationHeader = authorizationHeader
                         self._extender.fetchAuthorizationHeaderButton.setEnabled(True)
-

--- a/gui/save_restore.py
+++ b/gui/save_restore.py
@@ -7,7 +7,7 @@ from javax.swing import JFrame
 from java.io import File
 
 from table import LogEntry, UpdateTableEDT
-from helpers.http import IHttpRequestResponseImplementation
+from helpers.http import get_cookie_header_from_message, get_authorization_header_from_message, IHttpRequestResponseImplementation
 
 import csv, base64, json, re, sys
 
@@ -252,11 +252,11 @@ class SaveRestore():
 
                 lastRow = self._extender._log.size()
                 if lastRow > 0:
-                    cookiesHeader = self._extender.get_cookie_header_from_message(self._extender._log.get(lastRow - 1)._requestResponse)
+                    cookiesHeader = get_cookie_header_from_message(self._extender, self._extender._log.get(lastRow - 1)._requestResponse)
                     if cookiesHeader:
                         self._extender.lastCookiesHeader = cookiesHeader
                         self._extender.fetchCookiesHeaderButton.setEnabled(True)
-                    authorizationHeader = self._extender.get_authorization_header_from_message(self._extender._log.get(lastRow - 1)._requestResponse)
+                    authorizationHeader = get_authorization_header_from_message(self._extender, self._extender._log.get(lastRow - 1)._requestResponse)
                     if authorizationHeader:
                         self._extender.lastAuthorizationHeader = authorizationHeader
                         self._extender.fetchAuthorizationHeaderButton.setEnabled(True)


### PR DESCRIPTION
To be able to save and restore Autorize's configuration (which might get pretty extensive), I extended the existing save/restore functionality so that all relevant configuration options are included in the state file as well.