### PR TITLE
Update the regex of common files

### DIFF
--- a/gui/interception_filters.py
+++ b/gui/interception_filters.py
@@ -63,7 +63,7 @@ class InterceptionFilters():
 
         # Adding some default interception filters
         # self.IFModel.addElement("Scope items only: (Content is not required)") # commented for better first impression.
-        self._extender.IFModel.addElement("URL Not Contains (regex): \\.js|\\.css|\\.png|\\.jpg|\\.svg|\\.jpeg|\\.gif|\\.woff|\\.map|\\.bmp|\\.ico$")
+        self._extender.IFModel.addElement("URL Not Contains (regex): (\\.js|\\.css|\\.png|\\.jpg|\\.svg|\\.jpeg|\\.gif|\\.woff|\\.map|\\.bmp|\\.ico)(?![a-z]+)[?]*[\S]*$")
         self._extender.IFModel.addElement("Ignore spider requests: ")
         
         self._extender.IFText = JTextArea("", 5, 30)


### PR DESCRIPTION
The original regex match pages like `.jsp` or `.jsf` which are used as JavaServer Pages/Faces in some Java-based applications and used to dynamically generate pages (like PHP but for Java).

Regex 101 is self-explaining: https://regex101.com/r/NMFThd/1

Regex: `(\.js|\.css|\.png|\.jpg|\.svg|\.jpeg|\.gif|\.woff|\.map|\.bmp|\.ico)(?![a-z]+)[?]*[\S]*$`