### PR TITLE
Send to repeater

### DIFF
--- a/gui/tabs.py
+++ b/gui/tabs.py
@@ -25,6 +25,9 @@ from thread import start_new_thread
 
 from table import Table, LogEntry, TableRowFilter
 from helpers.filters import expand, collapse
+from javax.swing import KeyStroke
+from javax.swing import JTable
+from javax.swing import AbstractAction
 
 class ITabImpl(ITab):
     def __init__(self, extender):
@@ -75,6 +78,17 @@ class Tabs():
 
         sendRequestMenu2 = JMenuItem("Send Modified Request to Repeater")
         sendRequestMenu2.addActionListener(SendRequestRepeater(self._extender, self._extender._callbacks, False))
+
+        # Define the key combination for the shortcut
+        keyStroke = KeyStroke.getKeyStroke("F2")
+
+        # Get the input and action maps for the JTable
+        inputMap = self._extender.logTable.getInputMap(JTable.WHEN_FOCUSED)
+        actionMap = self._extender.logTable.getActionMap()
+
+        # Bind the key combination to the action
+        inputMap.put(keyStroke, "myShortcutAction")
+        actionMap.put("myShortcutAction", SendModifiedRequestToRepeaterAction(self._extender, self._extender._callbacks))
 
         sendResponseMenu = JMenuItem("Send Responses to Comparer")
         sendResponseMenu.addActionListener(SendResponseComparer(self._extender, self._extender._callbacks))
@@ -157,7 +171,7 @@ class SendRequestRepeater(ActionListener):
         proto = request.getHttpService().getProtocol()
         secure = True if proto == "https" else False
 
-        self._callbacks.sendToRepeater(host, port, secure, request.getRequest(), "Autorize");
+        self._callbacks.sendToRepeater(host, port, secure, request.getRequest(), "Autorize")
 
 class SendResponseComparer(ActionListener):
     def __init__(self, extender, callbacks):
@@ -237,4 +251,25 @@ class Mouseclick(MouseAdapter):
                 expand(self._extender, evt.getComponent())
             else:
                 collapse(self._extender, evt.getComponent())
-        
+
+class SendModifiedRequestToRepeaterAction(AbstractAction):
+    def __init__(self, extender, callbacks):
+        self._extender = extender
+        self._callbacks = callbacks
+
+    def actionPerformed(self, e):
+        # Get the selected row of the JTable
+        row = self._extender.logTable.getSelectedRow()
+
+        # Get the LogEntry object for the selected row
+        rowModelIndex = self._extender.logTable.convertRowIndexToModel(row)
+        entry = self._extender.tableModel.getValueAt(rowModelIndex, 0)
+
+        # Get the modified request
+        request = self._extender._currentlyDisplayedItem._requestResponse
+        host = request.getHttpService().getHost()
+        port = request.getHttpService().getPort()
+        proto = request.getHttpService().getProtocol()
+        secure = True if proto == "https" else False
+
+        self._callbacks.sendToRepeater(host, port, secure, request.getRequest(), "Autorize")

--- a/gui/tabs.py
+++ b/gui/tabs.py
@@ -28,6 +28,7 @@ from helpers.filters import expand, collapse
 from javax.swing import KeyStroke
 from javax.swing import JTable
 from javax.swing import AbstractAction
+from java.awt.event import KeyEvent
 
 class ITabImpl(ITab):
     def __init__(self, extender):
@@ -80,7 +81,8 @@ class Tabs():
         sendRequestMenu2.addActionListener(SendRequestRepeater(self._extender, self._extender._callbacks, False))
 
         # Define the key combination for the shortcut
-        keyStroke = KeyStroke.getKeyStroke("F2")
+
+        keyStroke = KeyStroke.getKeyStroke(KeyEvent.VK_R, Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx())
 
         # Get the input and action maps for the JTable
         inputMap = self._extender.logTable.getInputMap(JTable.WHEN_FOCUSED)


### PR DESCRIPTION
In response to the [feature request] ^R --> to repeater #92 I have implemented keyboard short cut so that when control + r or command+r is pressed, it will send whatever the currently selected row is to repeater. 