### PR TITLE
Change `checkAuthorization` function

### DIFF
--- a/authorization/authorization.py
+++ b/authorization/authorization.py
@@ -282,6 +282,15 @@ def checkBypass(self, oldStatusCode, newStatusCode, oldContent,
         return self.ENFORCED_STR
 
 def checkAuthorization(self, messageInfo, originalHeaders, checkUnauthorized):
+    # Check unauthorized request
+    if checkUnauthorized:
+        messageUnauthorized = makeMessage(self, messageInfo, True, False)
+        requestResponseUnauthorized = makeRequest(self, messageInfo, messageUnauthorized)
+        unauthorizedResponse = requestResponseUnauthorized.getResponse()
+        analyzedResponseUnauthorized = self._helpers.analyzeResponse(unauthorizedResponse)
+        statusCodeUnauthorized = analyzedResponseUnauthorized.getHeaders()[0]
+        contentUnauthorized = getResponseBody(self, requestResponseUnauthorized)
+
     message = makeMessage(self, messageInfo, True, True)
     requestResponse = makeRequest(self, messageInfo, message)
     newResponse = requestResponse.getResponse()
@@ -291,15 +300,6 @@ def checkAuthorization(self, messageInfo, originalHeaders, checkUnauthorized):
     newStatusCode = analyzedResponse.getHeaders()[0]
     oldContent = getResponseBody(self, messageInfo)
     newContent = getResponseBody(self, requestResponse)
-
-    # Check unauthorized request
-    if checkUnauthorized:
-        messageUnauthorized = makeMessage(self, messageInfo, True, False)
-        requestResponseUnauthorized = makeRequest(self, messageInfo, messageUnauthorized)
-        unauthorizedResponse = requestResponseUnauthorized.getResponse()
-        analyzedResponseUnauthorized = self._helpers.analyzeResponse(unauthorizedResponse)
-        statusCodeUnauthorized = analyzedResponseUnauthorized.getHeaders()[0]
-        contentUnauthorized = getResponseBody(self, requestResponseUnauthorized)
 
     EDFilters = self.EDModel.toArray()
 


### PR DESCRIPTION
When checking for IDORs or similar vulnerabilities, it's important to consider that certain actions, such as deleting a post or voting on a post, may only be performed once. Sending the original request is likely to succeed, whereas unauthorized or modified requests may not work as the original has already been executed (for example: the post has been deleted).