### PR TITLE
Update checkBypass so that user-defined detection rules take priority.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Autorize is an automatic authorization enforcement detection extension for Burp 
 2.	Download Jython standalone JAR: http://www.jython.org/download.html
 3.	Open burp -> Extender -> Options -> Python Environment -> Select File -> Choose the Jython standalone JAR
 4.	Install Autorize from the BApp Store or follow these steps:
-5.	Download the Autorize.py file.
+5.	Clone the repo or download it and unzip it.
 6.	Open Burp -> Extender -> Extensions -> Add -> Choose Autorize.py file.
 7.	See the Autorize tab and enjoy automatic authorization detection :)
 

--- a/authorization/authorization.py
+++ b/authorization/authorization.py
@@ -268,18 +268,19 @@ def auth_enforced_via_enforcement_detectors(self, filters, requestResponse, andO
 
 def checkBypass(self, oldStatusCode, newStatusCode, oldContent,
                  newContent, filters, requestResponse, andOrEnforcement):
-    if oldStatusCode == newStatusCode:
-        auth_enforced = 0
-        if len(filters) > 0:
-            auth_enforced = auth_enforced_via_enforcement_detectors(self, filters, requestResponse, andOrEnforcement)
+    if len(filters) > 0:
+        auth_enforced = auth_enforced_via_enforcement_detectors(self, filters, requestResponse, andOrEnforcement)
         if auth_enforced:
             return self.ENFORCED_STR
-        elif oldContent == newContent:
+        else:
+            return self.BYPASSSED_STR
+    else:
+        if oldStatusCode != newStatusCode:
+            return self.ENFORCED_STR
+        if oldContent == newContent:
             return self.BYPASSSED_STR
         else:
             return self.IS_ENFORCED_STR
-    else:
-        return self.ENFORCED_STR
 
 def checkAuthorization(self, messageInfo, originalHeaders, checkUnauthorized):
     message = makeMessage(self, messageInfo, True, True)


### PR DESCRIPTION
Original logic would always report "Is enforced???" when response bodies were not identical, even if the Enforcement Detection rules were set to indicate "Bypassed" or "Enforced"

This caused a case of clear "bypass" to be reported as "Is enforced???" (even with a custom detection rule) because the authenticated user's username was part of the response. The low-priv user got the same information as the high-priv user, but Autorize didn't report it because the different usernames made the response bodies not completely identical.

This PR separates the logic in checkBypass as follows:

If there are filters, then those filters alone determine either "Enforced" or "Bypassed"

If there are no filters, then use the existing logic:
If status codes do not match, then report "Enforced"
If status codes DO match and response content also is identical, report "Bypassed"
If status codes match but response content is not identical, report "Is enforced???"