### PR TITLE
Fix improper removal of NOT in enforcement detector strings

### DIFF
--- a/authorization/authorization.py
+++ b/authorization/authorization.py
@@ -223,8 +223,10 @@ def auth_enforced_via_enforcement_detectors(self, filters, requestResponse, andO
 
     for filter in filters:
         filter = self._helpers.bytesToString(bytes(filter))
-        inverse = "NOT" in filter
-        filter = filter.replace(" NOT", "")
+        filter_kv = filter.split(":", 1)
+        inverse = "NOT" in filter_kv[0]
+        filter_kv[0] = filter_kv[0].replace(" NOT", "")
+        filter = ":".join(filter_kv)
 
         if filter.startswith("Status code equals: "):
             statusCode = filter[20:]


### PR DESCRIPTION
First of all, thank you for creating such an awesome extension. It's been invaluable for a lot of my pen test work.

Today I noticed that Enforcement and Unauthenticated Detector rules which contain `NOT` in the detection string are incorrectly interpreted, resulting in a `UnboundLocalError` error when the `auth_enforced_via_enforcement_detector()` function is called.

![Screenshot 2024-11-22 at 19 08 55](https://github.com/user-attachments/assets/5a36536a-47a0-401a-88c9-61c58258be4b)

For example, the string `Body (simple string): NOT_AUTHORIZED` will:
1. incorrectly set the `inverse` variable to True (because of the `NOT` in `NOT_AUTHORIZED`).
2. remove ` NOT`, making the filter string `Body (simple string):_AUTHORIZED`.
3. skip all if-statements (due to the now malformed string from step 2).

The end result is that `filterMatched` does not get a value assigned to it, resulting in the "UnboundLocalError: local variable 'filterMatched' referenced before assignment" error shown in the screenshot.

This PR proposes the following fix which:
1. splits the filter string into a list of two items at the first `:`.
2. checks for the presence of `NOT` in the first list item.
3. removes ` NOT` from the first list item.
4. recombines both list items again.

